### PR TITLE
chore: update vendored rlang sources

### DIFF
--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -74,7 +74,10 @@ r_obj* r_env_get(r_obj* env, r_obj* sym) {
   }
 
   if (r_typeof(out) == R_TYPE_promise) {
-    return Rf_eval(out, env);
+    KEEP(out);
+    out = Rf_eval(out, env);
+    FREE(1);
+    return out;
   }
 
   return out;


### PR DESCRIPTION
Automated update of vendored `rlang` C sources from `r-lib/rlang`.

This PR updates the contents of `src/rlang/` to match the latest upstream source.

Closes #266