### PR TITLE
Update vendored rlang `r_env_poke`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ LinkingTo:
 VignetteBuilder:
     knitr
 Remotes:
+    r-lib/rlang,
     r-lib/vctrs
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/src/rlang/cnd.c
+++ b/src/rlang/cnd.c
@@ -43,7 +43,7 @@ void r_abort(const char* fmt, ...) {
   // Evaluate in a mask but forward error call to the current frame
   r_obj* frame = KEEP(r_peek_frame());
   r_obj* mask = KEEP(r_alloc_environment(2, frame));
-  r_env_poke(mask, r_syms.error_call_flag, frame);
+  r_env_bind(mask, r_syms.error_call_flag, frame);
 
   struct r_pair args[] = {
     { r_syms.message, message }

--- a/src/rlang/debug.c
+++ b/src/rlang/debug.c
@@ -8,7 +8,7 @@ void r_sexp_inspect(r_obj* x) {
 }
 
 void r_browse(r_obj* x) {
-  r_env_poke(r_envs.global, r_sym(".debug"), x);
+  r_env_bind(r_envs.global, r_sym(".debug"), x);
 
   r_printf("Object saved in `.debug`:\n");
   r_obj_print(x);

--- a/src/rlang/decl/env-binding-decl.h
+++ b/src/rlang/decl/env-binding-decl.h
@@ -1,0 +1,4 @@
+extern r_obj* rlang_ns_env;
+
+static r_obj* bind_delayed_call;
+static r_obj* bind_delayed_value_node;

--- a/src/rlang/decl/env-decl.h
+++ b/src/rlang/decl/env-decl.h
@@ -20,13 +20,6 @@ static
 r_obj* remove_call;
 
 static
-r_obj* poke_lazy_call;
-
-static
-r_obj* poke_lazy_value_node;
-
-
-static
 r_obj* env2list_call;
 
 static

--- a/src/rlang/env-binding.c
+++ b/src/rlang/env-binding.c
@@ -1,14 +1,10 @@
 #include "rlang.h"
 #include "env.h"
+#include "decl/env-binding-decl.h"
 
+// https://bugs.r-project.org/show_bug.cgi?id=18928
+#define RLANG_HAS_R_BINDING_API 0
 
-bool r_env_binding_is_promise(r_obj* env, r_obj* sym) {
-  r_obj* obj = r_env_find(env, sym);
-  return r_typeof(obj) == R_TYPE_promise && PRVALUE(obj) == r_syms.unbound;
-}
-bool r_env_binding_is_active(r_obj* env, r_obj* sym) {
-  return R_BindingIsActive(sym, env);
-}
 
 static r_obj* new_binding_types(r_ssize n) {
   r_obj* types = r_alloc_integer(n);
@@ -19,19 +15,7 @@ static r_obj* new_binding_types(r_ssize n) {
   return types;
 }
 
-static enum r_env_binding_type which_env_binding(r_obj* env, r_obj* sym) {
-  if (r_env_binding_is_active(env, sym)) {
-    // Check for active bindings first, since promise detection triggers
-    // active bindings through `r_env_find()` (#1376)
-    return R_ENV_BINDING_TYPE_active;
-  }
 
-  if (r_env_binding_is_promise(env, sym)) {
-    return R_ENV_BINDING_TYPE_promise;
-  }
-
-  return R_ENV_BINDING_TYPE_value;
-}
 
 static inline r_obj* binding_as_sym(bool list, r_obj* bindings, r_ssize i) {
   if (list) {
@@ -54,7 +38,8 @@ static r_ssize detect_special_binding(r_obj* env,
 
   for (r_ssize i = 0; i < n; ++i) {
     r_obj* sym = binding_as_sym(symbols, bindings, i);
-    if (which_env_binding(env, sym)) {
+    enum r_env_binding_type type = r_env_binding_type(env, sym);
+    if (type == R_ENV_BINDING_TYPE_active || type == R_ENV_BINDING_TYPE_delayed) {
       return i;
     }
   }
@@ -82,11 +67,17 @@ r_obj* r_env_binding_types(r_obj* env, r_obj* bindings) {
 
   r_ssize n = r_length(bindings);
   r_obj* types = KEEP(new_binding_types(n));
-  int* types_ptr = r_int_begin(types) + i;
+  int* types_ptr = r_int_begin(types);
+
+  // Fill value type for bindings before first special binding
+  for (r_ssize j = 0; j < i; ++j) {
+    *types_ptr = R_ENV_BINDING_TYPE_value;
+    ++types_ptr;
+  }
 
   while (i < n) {
     r_obj* sym = binding_as_sym(symbols, bindings, i);
-    *types_ptr = which_env_binding(env, sym);
+    *types_ptr = r_env_binding_type(env, sym);
 
     ++i;
     ++types_ptr;
@@ -94,4 +85,182 @@ r_obj* r_env_binding_types(r_obj* env, r_obj* bindings) {
 
   FREE(1);
   return types;
+}
+
+// This does an extra alloc, see https://bugs.r-project.org/show_bug.cgi?id=18928#c2
+r_obj* r_env_syms(r_obj* env) {
+  r_obj* nms = KEEP(r_env_names(env));
+  r_ssize n = r_length(nms);
+
+  r_obj* out = KEEP(r_alloc_list(n));
+  r_obj* const * v_nms = r_chr_cbegin(nms);
+
+  for (r_ssize i = 0; i < n; ++i) {
+    r_list_poke(out, i, r_str_as_symbol(v_nms[i]));
+  }
+
+  FREE(2);
+  return out;
+}
+
+
+// Binding type API
+// Implements future R API from https://bugs.r-project.org/show_bug.cgi?id=18928
+
+enum r_env_binding_type r_env_binding_type(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  switch (R_GetBindingType(sym, env)) {
+  case R_BindingTypeUnbound: return R_ENV_BINDING_TYPE_unbound;
+  case R_BindingTypeValue:   return R_ENV_BINDING_TYPE_value;
+  case R_BindingTypeMissing: return R_ENV_BINDING_TYPE_missing;
+  case R_BindingTypeDelayed: return R_ENV_BINDING_TYPE_delayed;
+  case R_BindingTypeForced:  return R_ENV_BINDING_TYPE_forced;
+  case R_BindingTypeActive:  return R_ENV_BINDING_TYPE_active;
+  }
+  r_stop_unreachable();
+#else
+  // Active binding check must come first since `r_env_find()` triggers them
+  if (R_BindingIsActive(sym, env)) {
+    return R_ENV_BINDING_TYPE_active;
+  }
+
+  r_obj* value = r_env_find(env, sym);
+
+  if (value == r_syms.unbound) {
+    return R_ENV_BINDING_TYPE_unbound;
+  }
+
+  if (value == r_missing_arg) {
+    return R_ENV_BINDING_TYPE_missing;
+  }
+
+  if (r_typeof(value) == R_TYPE_promise) {
+    if (PRVALUE(value) == r_syms.unbound) {
+      return R_ENV_BINDING_TYPE_delayed;
+    } else {
+      return R_ENV_BINDING_TYPE_forced;
+    }
+  }
+
+  return R_ENV_BINDING_TYPE_value;
+#endif
+}
+
+
+// Binding constructors
+
+void r_env_bind_active(r_obj* env, r_obj* sym, r_obj* fn) {
+  KEEP(fn);
+  r_env_unbind(env, sym);
+  R_MakeActiveBinding(sym, fn, env);
+  FREE(1);
+}
+
+void r_env_bind_delayed(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env) {
+#if RLANG_HAS_R_BINDING_API
+  R_MakeDelayedBinding(sym, expr, eval_env, env);
+#else
+  KEEP(expr);
+  r_obj* name = KEEP(r_sym_as_utf8_character(sym));
+
+  r_node_poke_car(bind_delayed_value_node, expr);
+  r_eval_with_xyz(bind_delayed_call, name, env, eval_env, rlang_ns_env);
+  r_node_poke_car(bind_delayed_value_node, r_null);
+
+  FREE(2);
+#endif
+}
+
+void r_env_bind_forced(r_obj* env, r_obj* sym, r_obj* expr, r_obj* value) {
+#if RLANG_HAS_R_BINDING_API
+  R_MakeForcedBinding(sym, expr, value, env);
+#else
+  // Creating an evaluated promise requires internal R API (`R_mkEVPROMISE`).
+  // Create a delayed binding and force it manually.
+  r_env_bind_delayed(env, sym, expr, r_envs.empty);
+
+  r_obj* promise = r_env_find(env, sym);
+  SET_PRVALUE(promise, value);
+  SET_PRENV(promise, r_null);
+#endif
+}
+
+void r_env_bind_missing(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  R_MakeMissingBinding(sym, env);
+#else
+  Rf_defineVar(sym, r_missing_arg, env);
+#endif
+}
+
+
+// Delayed binding accessors
+
+r_obj* r_env_binding_delayed_expr(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  return R_DelayedBindingExpression(sym, env);
+#else
+  r_obj* value = r_env_find(env, sym);
+
+  if (r_typeof(value) != R_TYPE_promise) {
+    r_abort("Not a promise binding.");
+  }
+  if (PRVALUE(value) != r_syms.unbound) {
+    r_abort("Not a delayed binding.");
+  }
+
+  return R_PromiseExpr(value);
+#endif
+}
+
+r_obj* r_env_binding_delayed_env(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  return R_DelayedBindingEnvironment(sym, env);
+#else
+  r_obj* value = r_env_find(env, sym);
+
+  if (r_typeof(value) != R_TYPE_promise) {
+    r_abort("Not a promise binding.");
+  }
+  if (PRVALUE(value) != r_syms.unbound) {
+    r_abort("Not a delayed binding.");
+  }
+
+  return PRENV(value);
+#endif
+}
+
+
+// Forced binding accessors
+
+r_obj* r_env_binding_forced_expr(r_obj* env, r_obj* sym) {
+#if RLANG_HAS_R_BINDING_API
+  return R_ForcedBindingExpression(sym, env);
+#else
+  r_obj* value = r_env_find(env, sym);
+
+  if (r_typeof(value) != R_TYPE_promise) {
+    r_abort("Not a promise binding.");
+  }
+  if (PRVALUE(value) == r_syms.unbound) {
+    r_abort("Not a forced binding.");
+  }
+
+  return R_PromiseExpr(value);
+#endif
+}
+
+
+// Active binding accessors
+
+r_obj* r_env_binding_active_fn(r_obj* env, r_obj* sym) {
+  return R_ActiveBindingFunction(sym, env);
+}
+
+
+void r_init_library_env_binding(void) {
+  bind_delayed_call = r_parse("delayedAssign(x, value = NULL, assign.env = y, eval.env = z)");
+  r_preserve(bind_delayed_call);
+
+  bind_delayed_value_node = r_node_cddr(bind_delayed_call);
 }

--- a/src/rlang/env-binding.h
+++ b/src/rlang/env-binding.h
@@ -6,14 +6,51 @@
 #include "rlang-types.h"
 
 enum r_env_binding_type {
-  R_ENV_BINDING_TYPE_value = 0,
-  R_ENV_BINDING_TYPE_promise,
-  R_ENV_BINDING_TYPE_active
+  R_ENV_BINDING_TYPE_unbound = 0,
+  R_ENV_BINDING_TYPE_value = 1,
+  R_ENV_BINDING_TYPE_missing = 2,
+  R_ENV_BINDING_TYPE_delayed = 3,
+  R_ENV_BINDING_TYPE_forced = 4,
+  R_ENV_BINDING_TYPE_active = 5
 };
 
-bool r_env_binding_is_promise(r_obj* env, r_obj* sym);
-bool r_env_binding_is_active(r_obj* env, r_obj* sym);
-r_obj* r_env_binding_types(r_obj* env, r_obj* bindings);
+enum r_env_binding_type r_env_binding_type(r_obj* env, r_obj* sym);
+r_obj* r_env_binding_types(r_obj* env, r_obj* syms);
+
+r_obj* r_env_syms(r_obj* env);
+
+// Binding constructors
+static inline
+void r_env_bind(r_obj* env, r_obj* sym, r_obj* value) {
+  // See rchk concerns in https://github.com/r-lib/rlang/commit/28ce7b01
+  KEEP(value);
+  Rf_defineVar(sym, value, env);
+  FREE(1);
+}
+
+// Silently ignores bindings that are not defined in `env`.
+static inline
+void r_env_unbind(r_obj* env, r_obj* sym) {
+  R_removeVarFromFrame(sym, env);
+}
+
+void r_env_bind_active(r_obj* env, r_obj* sym, r_obj* fn);
+void r_env_bind_delayed(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env);
+void r_env_bind_forced(r_obj* env, r_obj* sym, r_obj* expr, r_obj* value);
+void r_env_bind_missing(r_obj* env, r_obj* sym);
+
+// Delayed binding accessors
+r_obj* r_env_binding_delayed_expr(r_obj* env, r_obj* sym);
+r_obj* r_env_binding_delayed_env(r_obj* env, r_obj* sym);
+
+// Forced binding accessors
+r_obj* r_env_binding_forced_expr(r_obj* env, r_obj* sym);
+r_obj* r_env_binding_forced_value(r_obj* env, r_obj* sym);
+
+// Active binding accessors
+r_obj* r_env_binding_active_fn(r_obj* env, r_obj* sym);
+
+void r_init_library_env_binding(void);
 
 
 #endif

--- a/src/rlang/env.c
+++ b/src/rlang/env.c
@@ -65,37 +65,60 @@ r_obj* r_env_clone(r_obj* env, r_obj* parent) {
 }
 
 void r_env_coalesce(r_obj* env, r_obj* from) {
-  r_obj* nms = KEEP(r_env_names(from));
-  r_obj* types = KEEP(r_env_binding_types(from, nms));
+  r_obj* syms = KEEP(r_env_syms(from));
+  r_obj* types = KEEP(r_env_binding_types(from, syms));
 
   if (types == r_null) {
-    env_coalesce_plain(env, from, nms);
+    env_coalesce_plain(env, from, syms);
     FREE(2);
     return;
   }
 
-  r_ssize n = r_length(nms);
-  r_obj* const * v_nms = r_chr_cbegin(nms);
+  r_ssize n = r_length(syms);
+  r_obj* const * v_syms = r_list_cbegin(syms);
   enum r_env_binding_type* v_types = (enum r_env_binding_type*) r_int_begin(types);
 
   for (r_ssize i = 0; i < n; ++i) {
-    r_obj* sym = r_str_as_symbol(v_nms[i]);
+    r_obj* sym = v_syms[i];
 
     if (r_env_has(env, sym)) {
       continue;
     }
 
     switch (v_types[i]) {
-    case R_ENV_BINDING_TYPE_value:
-    case R_ENV_BINDING_TYPE_promise:
-      r_env_poke(env, sym, r_env_find(from, sym));
+    case R_ENV_BINDING_TYPE_unbound:
       break;
 
-    case R_ENV_BINDING_TYPE_active: {
-      r_obj* fn = R_ActiveBindingFunction(sym, from);
-      r_env_poke_active(env, sym, fn);
+    case R_ENV_BINDING_TYPE_value:
+      r_env_bind(env, sym, r_env_find(from, sym));
       break;
-    }}
+
+    case R_ENV_BINDING_TYPE_delayed:
+      r_env_bind_delayed(
+        env,
+        sym,
+        r_env_binding_delayed_expr(from, sym),
+        r_env_binding_delayed_env(from, sym)
+      );
+      break;
+
+    case R_ENV_BINDING_TYPE_forced:
+      r_env_bind_forced(
+        env,
+        sym,
+        r_env_binding_forced_expr(from, sym),
+        r_env_get(from, sym)
+      );
+      break;
+
+    case R_ENV_BINDING_TYPE_missing:
+      r_env_bind_missing(env, sym);
+      break;
+
+    case R_ENV_BINDING_TYPE_active:
+      r_env_bind_active(env, sym, r_env_binding_active_fn(from, sym));
+      break;
+    }
   }
 
   FREE(2);
@@ -103,18 +126,18 @@ void r_env_coalesce(r_obj* env, r_obj* from) {
 }
 
 static
-void env_coalesce_plain(r_obj* env, r_obj* from, r_obj* nms) {
-  r_ssize n = r_length(nms);
-  r_obj* const * v_nms = r_chr_cbegin(nms);
+void env_coalesce_plain(r_obj* env, r_obj* from, r_obj* syms) {
+  r_ssize n = r_length(syms);
+  r_obj* const * v_syms = r_list_cbegin(syms);
 
   for (r_ssize i = 0; i < n; ++i) {
-    r_obj* sym = r_str_as_symbol(v_nms[i]);
+    r_obj* sym = v_syms[i];
 
     if (r_env_has(env, sym)) {
       continue;
     }
 
-    r_env_poke(env, sym, r_env_find(from, sym));
+    r_env_bind(env, sym, r_env_find(from, sym));
   }
 
   return;
@@ -124,18 +147,6 @@ r_obj* r_list_as_environment(r_obj* x, r_obj* parent) {
   parent = parent ? parent : r_envs.empty;
   return eval_with_xy(list2env_call, x, parent);
 }
-
-void r_env_poke_lazy(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env) {
-  KEEP(expr);
-  r_obj* name = KEEP(r_sym_as_utf8_character(sym));
-
-  r_node_poke_car(poke_lazy_value_node, expr);
-  r_eval_with_xyz(poke_lazy_call, name, env, eval_env, rlang_ns_env);
-  r_node_poke_car(poke_lazy_value_node, r_null);
-
-  FREE(2);
-}
-
 
 #if RLANG_USE_R_EXISTS
 bool r__env_has(r_obj* env, r_obj* sym) {
@@ -240,11 +251,6 @@ void r_init_library_env(void) {
   list2env_call = r_parse("list2env(x, envir = NULL, parent = y, hash = TRUE)");
   r_preserve(list2env_call);
 
-  poke_lazy_call = r_parse("delayedAssign(x, value = NULL, assign.env = y, eval.env = z)");
-  r_preserve(poke_lazy_call);
-
-  poke_lazy_value_node = r_node_cddr(poke_lazy_call);
-
   exists_call = r_parse("exists(y, envir = x, inherits = z)");
   r_preserve(exists_call);
 
@@ -273,12 +279,6 @@ r_obj* exists_call = NULL;
 
 static
 r_obj* remove_call = NULL;
-
-static
-r_obj* poke_lazy_call = NULL;
-
-static
-r_obj* poke_lazy_value_node = NULL;
 
 static
 r_obj* env2list_call = NULL;

--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -7,7 +7,6 @@
 #include "cnd.h"
 #include "globals.h"
 #include "obj.h"
-#include "rlang.h"
 #include "sym.h"
 
 #define RLANG_USE_R_EXISTS (R_VERSION < R_Version(4, 2, 0))
@@ -162,29 +161,6 @@ r_obj* r_env_clone(r_obj* env, r_obj* parent);
 
 void r_env_coalesce(r_obj* env, r_obj* from);
 
-
-// Silently ignores bindings that are not defined in `env`.
-static inline
-void r_env_unbind(r_obj* env, r_obj* sym) {
-  R_removeVarFromFrame(sym, env);
-}
-
-static inline
-void r_env_poke(r_obj* env, r_obj* sym, r_obj* value) {
-  KEEP(value);
-  Rf_defineVar(sym, value, env);
-  FREE(1);
-}
-
-void r_env_poke_lazy(r_obj* env, r_obj* sym, r_obj* expr, r_obj* eval_env);
-
-static inline
-void r_env_poke_active(r_obj* env, r_obj* sym, r_obj* fn) {
-  KEEP(fn);
-  r_env_unbind(env, sym);
-  R_MakeActiveBinding(sym, fn, env);
-  FREE(1);
-}
 
 bool r_env_inherits(r_obj* env, r_obj* ancestor, r_obj* top);
 

--- a/src/rlang/eval.c
+++ b/src/rlang/eval.c
@@ -3,7 +3,7 @@
 
 r_obj* r_eval_with_x(r_obj* call, r_obj* x, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(1, parent));
-  r_env_poke(env, r_syms.x, x);
+  r_env_bind(env, r_syms.x, x);
 
   r_obj* out = r_eval(call, env);
 
@@ -12,8 +12,8 @@ r_obj* r_eval_with_x(r_obj* call, r_obj* x, r_obj* parent) {
 }
 r_obj* r_eval_with_xy(r_obj* call, r_obj* x, r_obj* y, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(2, parent));
-  r_env_poke(env, r_syms.x, x);
-  r_env_poke(env, r_syms.y, y);
+  r_env_bind(env, r_syms.x, x);
+  r_env_bind(env, r_syms.y, y);
 
   r_obj* out = r_eval(call, env);
 
@@ -22,9 +22,9 @@ r_obj* r_eval_with_xy(r_obj* call, r_obj* x, r_obj* y, r_obj* parent) {
 }
 r_obj* r_eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(3, parent));
-  r_env_poke(env, r_syms.x, x);
-  r_env_poke(env, r_syms.y, y);
-  r_env_poke(env, r_syms.z, z);
+  r_env_bind(env, r_syms.x, x);
+  r_env_bind(env, r_syms.y, y);
+  r_env_bind(env, r_syms.z, z);
 
   r_obj* out = r_eval(call, env);
 
@@ -33,10 +33,10 @@ r_obj* r_eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z, r_obj* parent)
 }
 r_obj* r_eval_with_wxyz(r_obj* call, r_obj* w, r_obj* x, r_obj* y, r_obj* z, r_obj* parent) {
   r_obj* env = KEEP(r_alloc_environment(4, parent));
-  r_env_poke(env, r_syms.w, w);
-  r_env_poke(env, r_syms.x, x);
-  r_env_poke(env, r_syms.y, y);
-  r_env_poke(env, r_syms.z, z);
+  r_env_bind(env, r_syms.w, w);
+  r_env_bind(env, r_syms.x, x);
+  r_env_bind(env, r_syms.y, y);
+  r_env_bind(env, r_syms.z, z);
 
   r_obj* out = r_eval(call, env);
 
@@ -58,42 +58,42 @@ static r_obj* shared_xy_env;
 static r_obj* shared_xyz_env;
 
 r_obj* eval_with_x(r_obj* call, r_obj* x) {
-  r_env_poke(shared_x_env, r_syms.x, x);
+  r_env_bind(shared_x_env, r_syms.x, x);
 
   r_obj* out = KEEP(r_eval(call, shared_x_env));
 
   // Release for gc
-  r_env_poke(shared_x_env, r_syms.x, r_null);
+  r_env_bind(shared_x_env, r_syms.x, r_null);
 
   FREE(1);
   return out;
 }
 
 r_obj* eval_with_xy(r_obj* call, r_obj* x, r_obj* y) {
-  r_env_poke(shared_xy_env, r_syms.x, x);
-  r_env_poke(shared_xy_env, r_syms.y, y);
+  r_env_bind(shared_xy_env, r_syms.x, x);
+  r_env_bind(shared_xy_env, r_syms.y, y);
 
   r_obj* out = KEEP(r_eval(call, shared_xy_env));
 
   // Release for gc
-  r_env_poke(shared_xy_env, r_syms.x, r_null);
-  r_env_poke(shared_xy_env, r_syms.y, r_null);
+  r_env_bind(shared_xy_env, r_syms.x, r_null);
+  r_env_bind(shared_xy_env, r_syms.y, r_null);
 
   FREE(1);
   return out;
 }
 
 r_obj* eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z) {
-  r_env_poke(shared_xyz_env, r_syms.x, x);
-  r_env_poke(shared_xyz_env, r_syms.y, y);
-  r_env_poke(shared_xyz_env, r_syms.z, z);
+  r_env_bind(shared_xyz_env, r_syms.x, x);
+  r_env_bind(shared_xyz_env, r_syms.y, y);
+  r_env_bind(shared_xyz_env, r_syms.z, z);
 
   r_obj* out = KEEP(r_eval(call, shared_xyz_env));
 
   // Release for gc
-  r_env_poke(shared_xyz_env, r_syms.x, r_null);
-  r_env_poke(shared_xyz_env, r_syms.y, r_null);
-  r_env_poke(shared_xyz_env, r_syms.z, r_null);
+  r_env_bind(shared_xyz_env, r_syms.x, r_null);
+  r_env_bind(shared_xyz_env, r_syms.y, r_null);
+  r_env_bind(shared_xyz_env, r_syms.z, r_null);
 
   FREE(1);
   return out;
@@ -135,7 +135,7 @@ r_obj* r_exec_mask_n_call_poke(r_obj* fn_sym,
                                int n,
                                r_obj* env) {
   if (fn_sym != r_null) {
-    r_env_poke(env, fn_sym, fn);
+    r_env_bind(env, fn_sym, fn);
     fn = fn_sym;
   }
 
@@ -154,7 +154,7 @@ r_obj* r_exec_mask_n_call_poke(r_obj* fn_sym,
     } else {
       // If symbol is supplied, assign the value in the environment and
       // use the symbol instead of the value in the list of arguments
-      r_env_poke(env, tag, car);
+      r_env_bind(env, tag, car);
       r_node_poke_car(node, tag);
     }
 

--- a/src/rlang/obj.c
+++ b/src/rlang/obj.c
@@ -127,7 +127,7 @@ r_obj* r_as_label(r_obj* x) {
 void r_init_library_obj(r_obj* ns) {
   p_precious_dict = r_new_dict(PRECIOUS_DICT_INIT_SIZE);
   KEEP(p_precious_dict->shelter);
-  r_env_poke(ns,
+  r_env_bind(ns,
              r_sym(".__rlang_lib_precious_dict__."),
              p_precious_dict->shelter);
   FREE(1);

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -108,6 +108,7 @@ r_obj* r_init_library(r_obj* ns) {
   r_init_library_sym();
   r_init_library_eval();
   r_init_library_env();
+  r_init_library_env_binding();
   r_init_rlang_ns_env();
   r_init_library_arg();
   r_init_library_call();

--- a/src/utils.c
+++ b/src/utils.c
@@ -34,8 +34,8 @@ r_obj* apply_transform(r_obj* value, r_obj* fn) {
   r_obj* call = KEEP(r_call2(syms_transform, syms_value));
 
   r_obj* mask = KEEP(r_alloc_environment(2, R_GlobalEnv));
-  r_env_poke(mask, syms_transform, fn);
-  r_env_poke(mask, syms_value, value);
+  r_env_bind(mask, syms_transform, fn);
+  r_env_bind(mask, syms_value, value);
   r_obj* out = KEEP(r_eval(call, mask));
 
   FREE(3);


### PR DESCRIPTION
Rename `r_env_poke` to `r_env_bind` per r-lib/rlang/commit/1c04f9250b896c92054e0346f7fb610d011bdf33

Closes #272.