### PR TITLE
chore: update vendored rlang sources

### DIFF
--- a/src/rlang/decl/env-binding-decl.h
+++ b/src/rlang/decl/env-binding-decl.h
@@ -1,4 +1,1 @@
 extern r_obj* rlang_ns_env;
-
-static r_obj* bind_delayed_call;
-static r_obj* bind_delayed_value_node;

--- a/src/rlang/env.c
+++ b/src/rlang/env.c
@@ -90,25 +90,28 @@ void r_env_coalesce(r_obj* env, r_obj* from) {
       break;
 
     case R_ENV_BINDING_TYPE_value:
-      r_env_bind(env, sym, r_env_find(from, sym));
+      r_env_bind(env, sym, KEEP(r_env_get(from, sym)));
+      FREE(1);
       break;
 
     case R_ENV_BINDING_TYPE_delayed:
       r_env_bind_delayed(
         env,
         sym,
-        r_env_binding_delayed_expr(from, sym),
-        r_env_binding_delayed_env(from, sym)
+        KEEP(r_env_binding_delayed_expr(from, sym)),
+        KEEP(r_env_binding_delayed_env(from, sym))
       );
+      FREE(2);
       break;
 
     case R_ENV_BINDING_TYPE_forced:
       r_env_bind_forced(
         env,
         sym,
-        r_env_binding_forced_expr(from, sym),
-        r_env_get(from, sym)
+        KEEP(r_env_binding_forced_expr(from, sym)),
+        KEEP(r_env_get(from, sym))
       );
+      FREE(2);
       break;
 
     case R_ENV_BINDING_TYPE_missing:
@@ -116,7 +119,8 @@ void r_env_coalesce(r_obj* env, r_obj* from) {
       break;
 
     case R_ENV_BINDING_TYPE_active:
-      r_env_bind_active(env, sym, r_env_binding_active_fn(from, sym));
+      r_env_bind_active(env, sym, KEEP(r_env_binding_active_fn(from, sym)));
+      FREE(1);
       break;
     }
   }
@@ -137,7 +141,8 @@ void env_coalesce_plain(r_obj* env, r_obj* from, r_obj* syms) {
       continue;
     }
 
-    r_env_bind(env, sym, r_env_find(from, sym));
+    r_env_bind(env, sym, KEEP(r_env_get(from, sym)));
+    FREE(1);
   }
 
   return;
@@ -191,34 +196,41 @@ bool r_env_inherits(r_obj* env, r_obj* ancestor, r_obj* top) {
   return env == ancestor;
 }
 
-static
-r_obj* env_until(r_obj* env, r_obj* sym, r_obj* last) {
+r_obj* r_env_until(r_obj* env, r_obj* sym, r_obj* last) {
   r_obj* stop = r_envs.empty;
   if (last != r_envs.empty) {
     stop = r_env_parent(last);
   }
 
   while (true) {
-    if (env == r_envs.empty || r_env_has(env, sym)) {
+    if (env == r_envs.empty) {
+      return r_envs.empty;
+    }
+    if (r_env_has(env, sym)) {
       return env;
     }
 
     r_obj* next = r_env_parent(env);
     if (next == r_envs.empty || next == stop) {
-      return env;
+      return r_envs.empty;
     }
 
     env = next;
   }
 }
 
+r_obj* r_env_get_anywhere(r_obj* env, r_obj* sym) {
+  env = r_env_until(env, sym, r_envs.empty);
+  return r_env_get(env, sym);
+}
+
 r_obj* r_env_get_until(r_obj* env, r_obj* sym, r_obj* last) {
-  env = env_until(env, sym, last);
+  env = r_env_until(env, sym, last);
   return r_env_get(env, sym);
 }
 
 bool r_env_has_until(r_obj* env, r_obj* sym, r_obj* last) {
-  env = env_until(env, sym, last);
+  env = r_env_until(env, sym, last);
   return r_env_has(env, sym);
 }
 

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -108,7 +108,6 @@ r_obj* r_init_library(r_obj* ns) {
   r_init_library_sym();
   r_init_library_eval();
   r_init_library_env();
-  r_init_library_env_binding();
   r_init_rlang_ns_env();
   r_init_library_arg();
   r_init_library_call();


### PR DESCRIPTION
Automated update of vendored `rlang` C sources from `r-lib/rlang`.

This PR updates the contents of `src/rlang/` to match the latest upstream source.

Closes #274