### PR TITLE
chore: update vendored rlang sources

### DIFF
--- a/src/rlang/env-binding.c
+++ b/src/rlang/env-binding.c
@@ -152,6 +152,29 @@ enum r_env_binding_type r_env_binding_type(r_obj* env, r_obj* sym) {
 #endif
 }
 
+r_obj* r_env_get(r_obj* env, r_obj* sym) {
+  enum r_env_binding_type type = r_env_binding_type(env, sym);
+
+  if (type == R_ENV_BINDING_TYPE_unbound) {
+    r_abort("object '%s' not found", r_sym_c_string(sym));
+  }
+  if (type == R_ENV_BINDING_TYPE_missing) {
+    return r_missing_arg;
+  }
+
+#if R_VERSION >= R_Version(4, 5, 0)
+  return R_getVar(sym, env, TRUE);
+#else
+  r_obj* value = env_find(env, sym);
+  if (r_typeof(value) == R_TYPE_dots) {
+    return value;
+  }
+
+  // Handles value, delayed, forced, and active bindings
+  return Rf_eval(sym, env);
+#endif
+}
+
 
 // Binding constructors
 

--- a/src/rlang/env-binding.h
+++ b/src/rlang/env-binding.h
@@ -19,6 +19,8 @@ r_obj* r_env_binding_types(r_obj* env, r_obj* syms);
 
 r_obj* r_env_syms(r_obj* env);
 
+r_obj* r_env_get(r_obj* env, r_obj* sym);
+
 // Binding constructors
 static inline
 void r_env_bind(r_obj* env, r_obj* sym, r_obj* value) {
@@ -45,7 +47,6 @@ r_obj* r_env_binding_delayed_env(r_obj* env, r_obj* sym);
 
 // Forced binding accessors
 r_obj* r_env_binding_forced_expr(r_obj* env, r_obj* sym);
-r_obj* r_env_binding_forced_value(r_obj* env, r_obj* sym);
 
 // Active binding accessors
 r_obj* r_env_binding_active_fn(r_obj* env, r_obj* sym);

--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -5,10 +5,8 @@
 
 #include "rlang-types.h"
 #include "cnd.h"
-#include "env-binding.h"
 #include "globals.h"
 #include "obj.h"
-#include "sym.h"
 
 #define RLANG_USE_R_EXISTS (R_VERSION < R_Version(4, 2, 0))
 
@@ -50,21 +48,7 @@ bool r_is_namespace(r_obj* x) {
   return R_IsNamespaceEnv(x);
 }
 
-static inline
-r_obj* r_env_get(r_obj* env, r_obj* sym) {
-  enum r_env_binding_type type = r_env_binding_type(env, sym);
-
-  if (type == R_ENV_BINDING_TYPE_unbound) {
-    r_abort("object '%s' not found", r_sym_c_string(sym));
-  }
-  if (type == R_ENV_BINDING_TYPE_missing) {
-    return r_missing_arg;
-  }
-
-  // Handles value, delayed, forced, and active bindings
-  // `R_getVar()` only available on R < 4.5.0
-  return Rf_eval(sym, env);
-}
+r_obj* r_env_get(r_obj* env, r_obj* sym);
 
 r_obj* r_env_until(r_obj* env, r_obj* sym, r_obj* last);
 


### PR DESCRIPTION
Automated update of vendored `rlang` C sources from `r-lib/rlang`.

This PR updates the contents of `src/rlang/` to match the latest upstream source.

Closes #276