### PR TITLE
Remove skips

### DIFF
--- a/tests/testthat/test-tib_spec_basics.R
+++ b/tests/testthat/test-tib_spec_basics.R
@@ -153,7 +153,6 @@ test_that("special ptypes are not incorrectly recognized", {
 })
 
 test_that("tib_scalar warns for deprecated ptype_inner", {
-  skip_on_covr()
   withr::local_options(
     lifecycle_verbosity = "warning"
   )

--- a/tests/testthat/test-unpack_tspec.R
+++ b/tests/testthat/test-unpack_tspec.R
@@ -142,7 +142,6 @@ test_that("names are repaired (#165)", {
     )
   )
 
-  skip_if(paste0(version$major, ".", version$minor) <= '4.0')
   expect_snapshot({
     # `minimal` isn't supported
     (expect_error(unpack_tspec(spec, names_repair = "minimal")))


### PR DESCRIPTION
We now require R >= 4.1.0, so we don't have to check that in tests.

For `test-tib_spec_basics.R`, locally coverage works fine for the test that was previously skipped. It might fail on CI, though, so I'm seeing what happens.