### PR TITLE
Update vignette to use correct number of gh_users (six instead of four)

### DIFF
--- a/vignettes/tibblify.Rmd
+++ b/vignettes/tibblify.Rmd
@@ -28,7 +28,7 @@ These lists might come from an API in the form of JSON or from scraping XML.
 
 ## Example
 
-Let's start with `gh_users`, which is a list from the {repurrrsive} package containing information about four GitHub users. 
+Let's start with `gh_users`, which is a list from the {repurrrsive} package containing information about six GitHub users. 
 We'll select a subset of columns to keep the example relatively simple.
 
 ```{r}


### PR DESCRIPTION
Knowing how to count beyond four can still be useful :-)