### PR TITLE
Scrub demo tokens in Slack OpenAPI Definition

### DIFF
--- a/tests/testthat/fixtures/slack-openapi.json
+++ b/tests/testthat/fixtures/slack-openapi.json
@@ -18212,10 +18212,10 @@
                 "examples": {
                   "response": {
                     "value": {
-                      "access_token": "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
+                      "access_token": "xoxb-access-token-string",
                       "app_id": "A0KRD7HC3",
                       "authed_user": {
-                        "access_token": "xoxp-1234",
+                        "access_token": "xoxp-XXXX",
                         "id": "U1234",
                         "scope": "chat:write",
                         "token_type": "user"


### PR DESCRIPTION
Slack used things that looked like real tokens, which freaked out something.

Closes #349.